### PR TITLE
add beeline to all middlewares

### DIFF
--- a/openedx_errors/apps.py
+++ b/openedx_errors/apps.py
@@ -5,6 +5,8 @@ openedx_errors Django application initialization.
 from django.apps import AppConfig
 from openedx.core.djangoapps.plugins.constants import PluginURLs, ProjectType
 
+from .hacks import add_beeline_instruments_to_middlewares
+
 
 class OpenedxErrorsConfig(AppConfig):
     """
@@ -27,3 +29,6 @@ class OpenedxErrorsConfig(AppConfig):
             },
         },
     }
+
+    def ready(self):
+        add_beeline_instruments_to_middlewares()

--- a/openedx_errors/hacks.py
+++ b/openedx_errors/hacks.py
@@ -1,0 +1,14 @@
+import beeline
+
+from django.utils.deprecation import MiddlewareMixin
+
+
+def add_beeline_instruments_to_middlewares():
+    old_call = MiddlewareMixin.__call__
+
+    def patched_middeware_call(self, request):
+        trace_name = 'openedx_errors:middleware:{}'.format(self.__class__.__name__)
+        with beeline.tracer(trace_name):
+            return old_call(self, request)
+
+    MiddlewareMixin.__call__ = patched_middeware_call


### PR DESCRIPTION
a pretty hacky attempt to trace all middlewares.

This will show most middlewares in honeycomb staging. It'll be probably very ugly, but I'll see what to make of it.